### PR TITLE
[FEAT] 개인 레포지토리 Vercel 배포 자동화 설정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: git push into another repo to deploy to vercel
+
+on:
+  push:
+    branches: ["main", "develop"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: pandoc/latex
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install mustache (to update the date)
+        run: apk add ruby && gem install mustache
+      - name: creates output
+        run: sh ./build.sh
+      - name: Pushes to another repository
+        id: push_directory
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.AUTO_ACTIONS }}
+        with:
+          source-directory: "output"
+          destination-github-username: rhdmswls12
+          destination-repository-name: WAGWAG-frontend
+          user-email: ${{ secrets.EMAIL }}
+          commit-message: ${{ github.event.commits[0].message }}
+          target-branch: main
+      - name: Test get variable exported by push-to-another-repository
+        run: echo $DESTINATION_CLONED_DIRECTORY

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+cd ../
+mkdir output
+cp -R ./WAGWAG-frontend/* ./output
+cp -R ./output ./WAGWAG-frontend/


### PR DESCRIPTION
## 🚩 관련 이슈
[FEAT] 개인 레포지토리 Vercel 배포 자동화 설정

## 📌 반영 브랜치
feature/WAG-5-modalComponent -> dev

## 📋 내용
- [x] build.sh 스크립트 작성
- [x] GitHub Actions 워크플로우 생성, main과 develop 브랜치 푸시 시 개인 레포에 자동 푸시 설정
