### PR TITLE
[FEAT] #WAG 온보딩 카테고리 페이지 구현

### DIFF
--- a/src/app/onboarding/category/Category.module.scss
+++ b/src/app/onboarding/category/Category.module.scss
@@ -1,3 +1,6 @@
+@use "../../../styles/abstracts/variables" as *;
+@use "../../../styles/abstracts/mixins" as *;
+
 .container {
   width: 100%;
   height: 100vh;
@@ -5,10 +8,80 @@
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
+  text-align: center;
 }
-.stepcontainer {
+
+.wagLogo {
+  position: fixed;
+  top: 5rem;
+  left: 5rem;
+  width: 13.3rem;
+}
+
+.guideText {
+  @include font(title-sm);
+  padding-top: 17.5rem;
+  color: $white-color;
+  margin-bottom: 1.15rem;
+}
+
+.helperText {
+  @include font(text-md);
+  color: $gray-200;
+  .highlight {
+    color: $green-color;
+  }
+}
+
+.actionButton {
+  position: fixed;
+  bottom: 14.7rem;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.stepContainer {
   position: fixed;
   bottom: 7.5rem;
   left: 50%;
   transform: translateX(-50%);
+}
+
+.grid {
+  justify-items: center;
+  align-items: center;
+  margin-top: 8.95rem;
+  margin-bottom: 9.3rem;
+}
+
+.categoryGrid {
+  width: 36.45rem;
+  height: 13.124rem;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  column-gap: 2.3rem;
+  row-gap: 3.2rem;
+}
+
+.categorySelectButton {
+  width: 100%;
+  height: 3.8rem;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  margin: 0;
+}
+
+.lastRow {
+  display: flex;
+  gap: 2.3rem;
+  width: 36.45rem;
+  margin-top: 3.2rem;
+}
+
+.lastRow .categorySelectButton,
+.lastRow .button {
+  width: 100%;
 }

--- a/src/app/onboarding/category/page.tsx
+++ b/src/app/onboarding/category/page.tsx
@@ -6,20 +6,89 @@ import { ActionButton } from "@/components/atoms/Button/ActionButton";
 import { CategorySelectButton } from "@/components/atoms/Button/CategorySelectButton";
 import OnboardingStepIndicator from "@/components/atoms/OnboardingStep/StepIndicator";
 
+const CATEGORIES = [
+  "뷰티",
+  "운동",
+  "노래",
+  "게임",
+  "산책",
+  "음식",
+  "일상생활",
+  "타 지역 인기 와글",
+];
+
+const MAX_SELECT = 3;
+
+const FIRST_BUTTONS = CATEGORIES.slice(0, 6);
+const LAST_BUTTONS = CATEGORIES.slice(6);
+
 export default function CategoryPage() {
-  const [selected, setSelected] = useState(false);
+  const [selected, setSelected] = useState<string[]>([]);
   const router = useRouter();
+
+  const handleSelect = (category: string) => {
+    setSelected((prev) => {
+      if (prev.includes(category)) {
+        return prev.filter((item) => item !== category);
+      } else if (prev.length < MAX_SELECT) {
+        return [...prev, category];
+      } else {
+        return prev; // 3개 이상 선택 불가
+      }
+    });
+  };
+
   return (
     <>
+      <img className={styles.wagLogo} src="/wagwagLogo.svg" alt="WAGWAGLOGO" />
       <div className={styles.container}>
-        <CategorySelectButton
-          isSelected={selected}
-          onClick={() => setSelected((prev) => !prev)}
+        <h1 className={styles.guideText}>
+          waggle 님이 관심있는 주제를 알려주세요
+        </h1>
+        <h2 className={styles.helperText}>
+          <span className={styles.highlight}>* </span>
+          <span>내 취향에 맞는 와글을 더 편리하게 볼 수 있어요</span>
+        </h2>
+        <div className={styles.grid}>
+          <div className={styles.categoryGrid}>
+            {FIRST_BUTTONS.map((category) => (
+              <CategorySelectButton
+                key={category}
+                isSelected={selected.includes(category)}
+                onClick={() => handleSelect(category)}
+                disabled={
+                  selected.length >= MAX_SELECT && !selected.includes(category)
+                }
+                className={styles.categorySelectButton}
+              >
+                {category}
+              </CategorySelectButton>
+            ))}
+          </div>
+          <div className={styles.lastRow}>
+            {LAST_BUTTONS.map((category) => (
+              <CategorySelectButton
+                key={category}
+                isSelected={selected.includes(category)}
+                onClick={() => handleSelect(category)}
+                disabled={
+                  selected.length >= MAX_SELECT && !selected.includes(category)
+                }
+                className={styles.categorySelectButton}
+                wide={4.25}
+              >
+                {category}
+              </CategorySelectButton>
+            ))}
+          </div>
+        </div>
+        <ActionButton
+          onClick={() => router.push("../main")}
+          disabled={selected.length === 0 || selected.length > MAX_SELECT}
         >
-          운동
-        </CategorySelectButton>{" "}
-        <ActionButton onClick={() => router.push("../main")}>확인</ActionButton>
-        <div className={styles.stepcontainer}>
+          완료
+        </ActionButton>
+        <div className={styles.stepContainer}>
           <OnboardingStepIndicator />
         </div>
       </div>

--- a/src/components/atoms/Button/CategorySelectButton/index.tsx
+++ b/src/components/atoms/Button/CategorySelectButton/index.tsx
@@ -3,6 +3,7 @@ import styles from "./CategorySelectButton.module.scss";
 
 interface CategoryButtonProps extends ButtonProps {
   isSelected: boolean;
+  wide?: boolean | number;
 }
 
 export const CategorySelectButton = ({
@@ -10,11 +11,19 @@ export const CategorySelectButton = ({
   onClick,
   disabled,
   isSelected,
+  wide = false,
 }: CategoryButtonProps) => {
   //이렇게 가져다 쓰세요~
+  // wide가 숫자면 padding을 동적으로 계산
+  const dynamicStyle =
+    typeof wide === "number"
+      ? { paddingLeft: `${wide}rem`, paddingRight: `${wide}rem` }
+      : {};
+
   return (
     <button
-      className={`${styles.button} ${isSelected ? styles.selected : ""}`}
+      className={`${styles.button} ${isSelected ? styles.selected : ""} ${wide === true ? styles.wide : ""}`}
+      style={dynamicStyle}
       onClick={onClick}
       disabled={disabled}
     >


### PR DESCRIPTION
## 📌 반영 브랜치
feature/WAG-categoryPage -> develop

## 📋 내용
- [x] 카테고리 페이지 구현
- [x] 선택 버튼 컴포넌트 수정

<img src="https://github.com/user-attachments/assets/85ed62ee-c9a7-4258-921c-bf71bfcd0576" width="1440" />
<img src="https://github.com/user-attachments/assets/fdac5f23-2fcf-45be-838a-e49c76f8b7d1" width="1440" />

## 🚨 유의 사항
- 버튼은 최소 1개 최대 3개 클릭할 수 있게 하였습니다
- 이전 버튼 컴포넌트에서 마지막 줄 padding값 조정을 위해 좌 우 padding값을 값으로 넘겨서 조정할 수 있도록 수정하였습니다
- 로고, 타이틀, 부가텍스트는 이전에 만들어진 페이지와 네이밍을 일치시켰습니다