### PR TITLE
[Feat] 온보딩 정보 전역 상태 관리 및 persist 적용

### DIFF
--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -1,7 +1,11 @@
 "use client";
 // import { useRouter } from "next/navigation";
+import { useUserSettingStore } from "@/stores";
 
 export default function CategoryPage() {
   // const router = useRouter();
+  const { nickname, profileImage, selectedGu, selectedDong, categories } =
+    useUserSettingStore.getState();
+  console.log({ nickname, profileImage, selectedGu, selectedDong, categories });
   return <h1>메인페이지입니다.</h1>;
 }

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -1,11 +1,7 @@
 "use client";
 // import { useRouter } from "next/navigation";
-import { useUserSettingStore } from "@/stores";
 
 export default function CategoryPage() {
   // const router = useRouter();
-  const { nickname, profileImage, selectedGu, selectedDong, categories } =
-    useUserSettingStore.getState();
-  console.log({ nickname, profileImage, selectedGu, selectedDong, categories });
   return <h1>메인페이지입니다.</h1>;
 }

--- a/src/app/onboarding/category/page.tsx
+++ b/src/app/onboarding/category/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
 import styles from "./Category.module.scss";
 import { ActionButton } from "@/components/atoms/Button/ActionButton";
 import { CategorySelectButton } from "@/components/atoms/Button/CategorySelectButton";
 import OnboardingStepIndicator from "@/components/atoms/OnboardingStep/StepIndicator";
+import { useUserSettingStore } from "@/stores";
 
 const CATEGORIES = [
   "뷰티",
@@ -23,11 +23,11 @@ const FIRST_BUTTONS = CATEGORIES.slice(0, 6);
 const LAST_BUTTONS = CATEGORIES.slice(6);
 
 export default function CategoryPage() {
-  const [selected, setSelected] = useState<string[]>([]);
+  const { categories, setCategories } = useUserSettingStore();
   const router = useRouter();
 
   const handleSelect = (category: string) => {
-    setSelected((prev) => {
+    setCategories((prev) => {
       if (prev.includes(category)) {
         return prev.filter((item) => item !== category);
       } else if (prev.length < MAX_SELECT) {
@@ -54,10 +54,11 @@ export default function CategoryPage() {
             {FIRST_BUTTONS.map((category) => (
               <CategorySelectButton
                 key={category}
-                isSelected={selected.includes(category)}
+                isSelected={categories.includes(category)}
                 onClick={() => handleSelect(category)}
                 disabled={
-                  selected.length >= MAX_SELECT && !selected.includes(category)
+                  categories.length >= MAX_SELECT &&
+                  !categories.includes(category)
                 }
                 className={styles.categorySelectButton}
               >
@@ -69,10 +70,11 @@ export default function CategoryPage() {
             {LAST_BUTTONS.map((category) => (
               <CategorySelectButton
                 key={category}
-                isSelected={selected.includes(category)}
+                isSelected={categories.includes(category)}
                 onClick={() => handleSelect(category)}
                 disabled={
-                  selected.length >= MAX_SELECT && !selected.includes(category)
+                  categories.length >= MAX_SELECT &&
+                  !categories.includes(category)
                 }
                 className={styles.categorySelectButton}
                 wide={4.25}
@@ -84,7 +86,7 @@ export default function CategoryPage() {
         </div>
         <ActionButton
           onClick={() => router.push("../main")}
-          disabled={selected.length === 0 || selected.length > MAX_SELECT}
+          disabled={categories.length === 0 || categories.length > MAX_SELECT}
         >
           완료
         </ActionButton>

--- a/src/app/onboarding/category/page.tsx
+++ b/src/app/onboarding/category/page.tsx
@@ -23,7 +23,7 @@ const FIRST_BUTTONS = CATEGORIES.slice(0, 6);
 const LAST_BUTTONS = CATEGORIES.slice(6);
 
 export default function CategoryPage() {
-  const { categories, setCategories } = useUserSettingStore();
+  const { categories, setCategories, reset } = useUserSettingStore();
   const router = useRouter();
 
   const handleSelect = (category: string) => {
@@ -36,6 +36,11 @@ export default function CategoryPage() {
         return prev; // 3개 이상 선택 불가
       }
     });
+  };
+
+  const handleComplete = () => {
+    reset(); // 상태 초기화
+    router.push("../main");
   };
 
   return (
@@ -85,7 +90,7 @@ export default function CategoryPage() {
           </div>
         </div>
         <ActionButton
-          onClick={() => router.push("../main")}
+          onClick={handleComplete}
           disabled={categories.length === 0 || categories.length > MAX_SELECT}
         >
           완료

--- a/src/app/onboarding/location/page.tsx
+++ b/src/app/onboarding/location/page.tsx
@@ -1,14 +1,14 @@
 "use client";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
 import styles from "./Location.module.scss";
 import { SEOUL_REGIONS } from "@/constants/regions";
 import { ActionButton } from "@/components/atoms/Button/ActionButton";
 import OnboardingStepIndicator from "@/components/atoms/OnboardingStep/StepIndicator";
+import { useUserSettingStore } from "@/stores";
 
 export default function LocationPage() {
-  const [selectedGu, setSelectedGu] = useState<string | null>("강남구");
-  const [selectedDong, setSelectedDong] = useState<string | null>("개포1동");
+  const { selectedGu, selectedDong, setSelectedGu, setSelectedDong } =
+    useUserSettingStore();
   const dongList = selectedGu ? SEOUL_REGIONS[selectedGu] : [];
   const guList = Object.keys(SEOUL_REGIONS);
   const router = useRouter();

--- a/src/app/onboarding/nickname/page.tsx
+++ b/src/app/onboarding/nickname/page.tsx
@@ -7,12 +7,13 @@ import OnboardingStepIndicator from "@/components/atoms/OnboardingStep/StepIndic
 import React, { useMemo, useRef, useState } from "react";
 import { HighlightText } from "./HighlightText";
 import Image from "next/image";
+import { useUserSettingStore } from "@/stores";
 
 // 비속어 방지 기능 필요
 export default function NicknamePage() {
-  const [profileImage, setProfileImageFile] = useState<string | null>(null);
+  const { nickname, setNickname, profileImage, setProfileImage } =
+    useUserSettingStore();
   const [imageError, setImageError] = useState("");
-  const [nickname, setNickname] = useState("");
   const router = useRouter();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -110,7 +111,7 @@ export default function NicknamePage() {
     reader.onload = (event) => {
       const result = event.target?.result;
       if (typeof result === "string") {
-        setProfileImageFile(result);
+        setProfileImage(result);
       }
     };
     reader.readAsDataURL(file);

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,3 +1,4 @@
 // zustand store 저장소를 모아두는 디렉토리입니다.
 // ex) userStore.ts : 유저 정보 저장소
 export * from "./modalStore";
+export * from "./userSettingStore";

--- a/src/stores/userSettingStore.ts
+++ b/src/stores/userSettingStore.ts
@@ -1,0 +1,43 @@
+import { create } from "zustand";
+
+interface UserSettingState {
+  nickname: string;
+  setNickname: (nickname: string) => void;
+  profileImage: string | null;
+  setProfileImage: (image: string | null) => void;
+  selectedGu: string | null;
+  selectedDong: string | null;
+  setSelectedGu: (gu: string | null) => void;
+  setSelectedDong: (dong: string | null) => void;
+  categories: string[];
+  setCategories: (
+    categories: string[] | ((prev: string[]) => string[])
+  ) => void;
+}
+
+export const useUserSettingStore = create<UserSettingState>((set) => ({
+  nickname: "",
+  setNickname: (nickname) => set({ nickname }),
+  profileImage: null,
+  setProfileImage: (image) => set({ profileImage: image }),
+  selectedGu: "강남구",
+  selectedDong: "개포1동",
+
+  setSelectedGu: (gu) =>
+    set(() => ({
+      selectedGu: gu,
+      selectedDong: null,
+    })),
+  setSelectedDong: (dong) =>
+    set(() => ({
+      selectedDong: dong,
+    })),
+  categories: [],
+  setCategories: (categories) =>
+    set((state) => ({
+      categories:
+        typeof categories === "function"
+          ? categories(state.categories)
+          : categories,
+    })),
+}));

--- a/src/stores/userSettingStore.ts
+++ b/src/stores/userSettingStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 
 interface UserSettingState {
   nickname: string;
@@ -13,31 +14,47 @@ interface UserSettingState {
   setCategories: (
     categories: string[] | ((prev: string[]) => string[])
   ) => void;
+  reset: () => void;
 }
 
-export const useUserSettingStore = create<UserSettingState>((set) => ({
-  nickname: "",
-  setNickname: (nickname) => set({ nickname }),
-  profileImage: null,
-  setProfileImage: (image) => set({ profileImage: image }),
-  selectedGu: "강남구",
-  selectedDong: "개포1동",
+export const useUserSettingStore = create(
+  persist<UserSettingState>(
+    (set) => ({
+      nickname: "",
+      setNickname: (nickname) => set({ nickname }),
+      profileImage: null,
+      setProfileImage: (image) => set({ profileImage: image }),
+      selectedGu: "강남구",
+      selectedDong: "개포1동",
 
-  setSelectedGu: (gu) =>
-    set(() => ({
-      selectedGu: gu,
-      selectedDong: null,
-    })),
-  setSelectedDong: (dong) =>
-    set(() => ({
-      selectedDong: dong,
-    })),
-  categories: [],
-  setCategories: (categories) =>
-    set((state) => ({
-      categories:
-        typeof categories === "function"
-          ? categories(state.categories)
-          : categories,
-    })),
-}));
+      setSelectedGu: (gu) =>
+        set(() => ({
+          selectedGu: gu,
+          selectedDong: null,
+        })),
+      setSelectedDong: (dong) =>
+        set(() => ({
+          selectedDong: dong,
+        })),
+      categories: [],
+      setCategories: (categories) =>
+        set((state) => ({
+          categories:
+            typeof categories === "function"
+              ? categories(state.categories)
+              : categories,
+        })),
+      reset: () =>
+        set(() => ({
+          nickname: "",
+          profileImage: null,
+          selectedGu: null,
+          selectedDong: null,
+          categories: [],
+        })),
+    }),
+    {
+      name: "user-settings",
+    }
+  )
+);


### PR DESCRIPTION
📌 반영 브랜치
feature/WAG-5-modalComponent -> dev

📋 내용

- 온보딩 단계에서 사용되는 사용자 설정 정보를 위한 Zustand 기반 전역 상태 store(`useUserSettingStore`) 추가
- persist 적용하여 상태가 로컬 스토리지에 저장되도록 설정
- 온보딩 마지막 단계(카테고리 선택 페이지)에서 완료 버튼 클릭 시 온보딩 정보 초기화

🚨 유의 사항
- 온보딩 설정 정보는 회원가입 직전까지만 유효한 임시 상태이므로 persist로 저장하되 회원가입 완료 후에는 명시적으로 초기화 되도록 설정했습니다.